### PR TITLE
Added permissions to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,10 @@ name: Automatic cucumber tests
 
 on: push
 
+permissions:
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added [required permissions](https://github.com/EnricoMi/publish-unit-test-result-action#permissions) as I was getting [403 Forbidden](https://github.com/ddikman/cucumber-web-tests/actions/runs/3357950164/jobs/5564257153) from the dependabot test runs.