### PR TITLE
New action for ruby setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up RVM
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Install Google Chrome


### PR DESCRIPTION
As per [failing build](https://github.com/ddikman/cucumber-web-tests/actions/runs/3645278985/jobs/6155284584) I changed the action used to setup ruby.

![image](https://user-images.githubusercontent.com/8461739/206357841-5fe159c3-ace4-49b6-99e1-72c3652a39c9.png)
